### PR TITLE
Fix example in README and default value for olm_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module "dev_software_olm_release" {
   cluster_config_file      = pathexpand("~/.kube/config")
   cluster_version          = "3.11"
   cluster_type             = "ocp3"
-  olm_version		   = "v0.20.0"
+  olm_version              = "v0.20.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ the olm namespaces for use by downstream modules.
 module "dev_software_olm_release" {
   source = "github.com/ibm-garage-cloud/garage-terraform-modules.git//self-managed/software/operator-lifecycle-manager?ref=olm"
 
-  cluster_config_file      = "~/.kube/config"
+  cluster_config_file      = pathexpand("~/.kube/config")
   cluster_version          = "3.11"
   cluster_type             = "ocp3"
+  olm_version		   = "v0.20.0"
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,5 +17,5 @@ variable "cluster_config_file" {
 variable "olm_version" {
   type        = string
   description = "The version of olm that will be installed"
-  default     = "0.18.1"
+  default     = "v0.18.1"
 }


### PR DESCRIPTION
As reported in https://github.com/cloud-native-toolkit/terraform-k8s-olm/issues/13 the current example from the README does not work. ```pathexpand``` should be used to get the full path to the user's home directory.
Furthermore the value for ```olm_version``` needs to be prefixed with a ```v``` for all version since ```v0.16.1```.