### PR TITLE
fix version string

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -17,5 +17,5 @@ variable "cluster_config_file" {
 variable "olm_version" {
   type        = string
   description = "The version of olm that will be installed"
-  default     = "0.18.1"
+  default     = "v0.18.1"
 }


### PR DESCRIPTION
The version string need to include v to allow the install script to access the release artifacts

Signed-off-by: Brian Innes <binnes@uk.ibm.com>